### PR TITLE
Increase ctest timeout from 45 to 200 seconds

### DIFF
--- a/config/daint.cmake
+++ b/config/daint.cmake
@@ -106,7 +106,7 @@ set(PAPI_LIBRARY     "${INSTALL_ROOT}/papi/${PAPI_VER}/lib/libpfm.so")
 
 set(CTEST_SITE "cray(daint)-${PYCICLE_BUILD_STAMP}-Boost-${BOOST_VER}")
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
-set(CTEST_TEST_TIMEOUT "45")
+set(CTEST_TEST_TIMEOUT "200")
 set(BUILD_PARALLELISM  "32")
 
 #######################################################################

--- a/config/greina.cmake
+++ b/config/greina.cmake
@@ -45,7 +45,7 @@ set(BUILD_PARALLELISM "8")
 
 set(CTEST_SITE "linux(greina)-gcc-${GCC_VER}-Boost-${BOOST_VER}")
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
-set(CTEST_TEST_TIMEOUT "45")
+set(CTEST_TEST_TIMEOUT "200")
 
 #######################################################################
 # The string that is used to drive cmake config step

--- a/config/jb-laptop.cmake
+++ b/config/jb-laptop.cmake
@@ -43,7 +43,7 @@ set(BUILD_PARALLELISM "8")
 
 set(CTEST_SITE "linux(jblaptop)-gcc-${GCC_VER}-Boost-${BOOST_VER}")
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
-set(CTEST_TEST_TIMEOUT "45")
+set(CTEST_TEST_TIMEOUT "200")
 
 #######################################################################
 # The string that is used to drive cmake config step


### PR DESCRIPTION
Some tests genuinely take a long time to finish, so to avoid false positives this increases the timeout to 200 seconds. This should not significantly increase the time to run all tests as long as there are only a few real timeouts, and hopefully the real timeouts will be more evident.

For example [here](http://cdash.cscs.ch/viewTest.php?onlyfailed&buildid=73037),  `tests.regressions.lcos_dir.fail_future_2667` can take up to 100 seconds to run on daint, presumably because `SCRATCH` is slow. `tests.regressions.lcos_dir.future_timed_wait_1025` takes a minimum of 40 seconds to run (because of sleeping in the test).