### PR TITLE
Change context regex to include more of the build name

### DIFF
--- a/pycicle.py
+++ b/pycicle.py
@@ -228,7 +228,7 @@ def scrape_testing_results(nickname, scrape_file, branch_id, branch_name, head_c
     Test_Errors   = 0
     Errors        = []
 
-    context = re.search(r'/build/.*-(.+)/pycicle-TAG.txt', scrape_file)
+    context = re.search(r'/build/.*?-(.+)/pycicle-TAG.txt', scrape_file)
 
     if context:
         origin = nickname + '-' + context.group(1)


### PR DESCRIPTION
This changes the "context" which is shown on PRs.

For example for a build folder `3036-gcc-6.2.0` the context changes from `daint-6.2.0` to `daint-gcc-6.2.0`.