### PR TITLE
Fix readme formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ locations and compute resources ditributed worldwide with different architecture
 To run locally and use machine daint for builds of the hpx project
 ```bash
 python ./pycicle.py -m daint -P hpx
-``` or for builds of the dca project
+```
+or for builds of the dca project
 ```
 python ./pycicle.py -m daint -P hpx
-
 ```
 
 ## options


### PR DESCRIPTION
The text after triple-backticks made non-code formatted as code, and vice versa. This fixes that.