### PR TITLE
Add command line option to set build type

### DIFF
--- a/config/dca/daint.cmake
+++ b/config/dca/daint.cmake
@@ -26,7 +26,7 @@ set(CMAKE_VER            "3.9.1")
 
 if (PYCICLE_COMPILER MATCHES "gcc")
   set(GCC_VER             "5.3.0")
-  set(PYCICLE_BUILD_STAMP "gcc-${GCC_VER}")
+  set(PYCICLE_BUILD_STAMP "gcc-${GCC_VER}-Boost-${BOOST_VER}-${PYCICLE_BUILD_TYPE}")
   #
   set(INSTALL_ROOT     "/apps/daint/UES/6.0.UP04/HPX")
   set(BOOST_ROOT       "${INSTALL_ROOT}/boost/${GCC_VER}/${BOOST_VER}")
@@ -61,7 +61,7 @@ set(PAPI_ROOT        "${INSTALL_ROOT}/papi/${PAPI_VER}")
 set(PAPI_INCLUDE_DIR "${INSTALL_ROOT}/papi/${PAPI_VER}/include")
 set(PAPI_LIBRARY     "${INSTALL_ROOT}/papi/${PAPI_VER}/lib/libpfm.so")
 
-set(CTEST_SITE "cray(daint)-${PYCICLE_BUILD_STAMP}-Boost-${BOOST_VER}")
+set(CTEST_SITE "cray(daint)")
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 set(CTEST_TEST_TIMEOUT "600")
 set(BUILD_PARALLELISM  "32")

--- a/config/hpx/daint.cmake
+++ b/config/hpx/daint.cmake
@@ -26,7 +26,7 @@ set(CMAKE_VER            "3.9.1")
 
 if (PYCICLE_COMPILER MATCHES "gcc")
   set(GCC_VER             "6.2.0")
-  set(PYCICLE_BUILD_STAMP "gcc-${GCC_VER}")
+  set(PYCICLE_BUILD_STAMP "gcc-${GCC_VER}-Boost-${BOOST_VER}-${PYCICLE_BUILD_TYPE}")
   #
   set(INSTALL_ROOT     "/apps/daint/UES/6.0.UP04/HPX")
   set(BOOST_ROOT       "${INSTALL_ROOT}/boost/${GCC_VER}/${BOOST_VER}")
@@ -60,7 +60,7 @@ elseif(PYCICLE_COMPILER MATCHES "clang")
   set(CMAKE_C_COMPILER   "${CLANG_ROOT}/bin/clang")
   set(CMAKE_CXX_COMPILER "${CLANG_ROOT}/bin/clang++")
   #
-  set(PYCICLE_BUILD_STAMP "clang-6.0.0")
+  set(PYCICLE_BUILD_STAMP "clang-6.0.0-Boost-${BOOST_VER}-${PYCICLE_BUILD_TYPE}")
   #
   set(OTF2_VER         "2.1")
   #
@@ -104,7 +104,7 @@ set(PAPI_ROOT        "${INSTALL_ROOT}/papi/${PAPI_VER}")
 set(PAPI_INCLUDE_DIR "${INSTALL_ROOT}/papi/${PAPI_VER}/include")
 set(PAPI_LIBRARY     "${INSTALL_ROOT}/papi/${PAPI_VER}/lib/libpfm.so")
 
-set(CTEST_SITE "cray(daint)-${PYCICLE_BUILD_STAMP}-Boost-${BOOST_VER}")
+set(CTEST_SITE "cray(daint)")
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 set(CTEST_TEST_TIMEOUT "200")
 set(BUILD_PARALLELISM  "32")

--- a/config/hpx/greina.cmake
+++ b/config/hpx/greina.cmake
@@ -26,7 +26,7 @@ set(OTF2_VER      "2.0")
 set(PAPI_VER      "5.5.1")
 set(BOOST_SUFFIX  "1_65_1")
 
-set(PYCICLE_BUILD_STAMP "gcc-${GCC_VER}")
+set(PYCICLE_BUILD_STAMP "gcc-${GCC_VER}-Boost-${BOOST_VER}-${PYCICLE_BUILD_TYPE}")
 
 set(INSTALL_ROOT     "/users/biddisco/apps")
 set(BOOST_ROOT       "${INSTALL_ROOT}/boost/${BOOST_VER}")
@@ -43,7 +43,7 @@ set(LDFLAGS    "-dynamic")
 set(LDCXXFLAGS "${LDFLAGS} -std c++14")
 set(BUILD_PARALLELISM "8")
 
-set(CTEST_SITE "linux(greina)-gcc-${GCC_VER}-Boost-${BOOST_VER}")
+set(CTEST_SITE "linux(greina)")
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 set(CTEST_TEST_TIMEOUT "200")
 

--- a/config/hpx/jb-laptop.cmake
+++ b/config/hpx/jb-laptop.cmake
@@ -41,7 +41,7 @@ set(LDFLAGS    "")
 set(LDCXXFLAGS "${LDFLAGS} -std c++14")
 set(BUILD_PARALLELISM "8")
 
-set(CTEST_SITE "linux(jblaptop)-gcc-${GCC_VER}-Boost-${BOOST_VER}")
+set(CTEST_SITE "linux(jblaptop)")
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 set(CTEST_TEST_TIMEOUT "200")
 

--- a/dashboard_script.cmake
+++ b/dashboard_script.cmake
@@ -19,11 +19,7 @@ message("PYCICLE_ROOT is  " ${PYCICLE_ROOT})
 message("Random string is " ${PYCICLE_RANDOM})
 message("COMPILER is      " ${PYCICLE_COMPILER})
 message("BOOST is         " ${PYCICLE_BOOST})
-
-#######################################################################
-# need to make this a passed in option
-#######################################################################
-set(CTEST_BUILD_CONFIGURATION "Release")
+message("Build type is    " ${PYCICLE_BUILD_TYPE})
 
 #######################################################################
 # Load machine specific settings
@@ -60,9 +56,9 @@ file(MAKE_DIRECTORY          "${PYCICLE_PR_ROOT}/")
 include(${CTEST_SOURCE_DIRECTORY}/CTestConfig.cmake)
 
 if (PYCICLE_PR STREQUAL "master")
-  set(CTEST_BUILD_NAME "${PYCICLE_BRANCH}-${CTEST_BUILD_CONFIGURATION}")
+  set(CTEST_BUILD_NAME "${PYCICLE_BRANCH}-${PYCICLE_BUILD_STAMP}")
 else()
-  set(CTEST_BUILD_NAME "${PYCICLE_PR}-${PYCICLE_BRANCH}-${CTEST_BUILD_CONFIGURATION}")
+  set(CTEST_BUILD_NAME "${PYCICLE_PR}-${PYCICLE_BRANCH}-${PYCICLE_BUILD_STAMP}")
 endif()
 
 #######################################################################
@@ -199,7 +195,7 @@ ctest_start(${CTEST_MODEL}
 )
 
 string(CONCAT CTEST_CONFIGURE_COMMAND
-  " ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE=${CTEST_BUILD_CONFIGURATION} "
+  " ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE=${PYCICLE_BUILD_TYPE} "
   " ${CTEST_BUILD_OPTIONS}"
   " ${CTEST_CONFIGURE_COMMAND} \"-G${CTEST_CMAKE_GENERATOR}\""
   " ${CTEST_CONFIGURE_COMMAND} \"${CTEST_SOURCE_DIRECTORY}\"")

--- a/dashboard_slurm.cmake
+++ b/dashboard_slurm.cmake
@@ -19,6 +19,7 @@ message("PYCICLE_ROOT is  " ${PYCICLE_ROOT})
 message("Random string is " ${PYCICLE_RANDOM})
 message("COMPILER is      " ${PYCICLE_COMPILER})
 message("BOOST is         " ${PYCICLE_BOOST})
+message("Build type is    " ${PYCICLE_BUILD_TYPE})
 
 #######################################################################
 # Load machine specific settings
@@ -41,6 +42,7 @@ set(PYCICLE_SLURM_TEMPLATE ${PYCICLE_SLURM_TEMPLATE}
   "-DPYCICLE_BRANCH=${PYCICLE_BRANCH} "
   "-DPYCICLE_COMPILER=${PYCICLE_COMPILER} "
   "-DPYCICLE_BOOST=${PYCICLE_BOOST} "
+  "-DPYCICLE_BUILD_TYPE=${PYCICLE_BUILD_TYPE} "
   "-DPYCICLE_MASTER=${PYCICLE_MASTER} \n"
 )
 

--- a/pycicle.py
+++ b/pycicle.py
@@ -74,6 +74,12 @@ parser.add_argument('-m', '--machines', dest='machines', nargs='+',
     default=machines, help='list of machines to use for testing')
 
 #--------------------------------------------------------------------------
+# CMake build type
+#--------------------------------------------------------------------------
+parser.add_argument('-b', '--build-type', dest='build_type',
+    default='Release', help='CMake build type used for all builds')
+
+#--------------------------------------------------------------------------
 # PR - when testing, limit checks to a single PR
 #--------------------------------------------------------------------------
 parser.add_argument('-p', '--pull-request', dest='pull_request', type=int,
@@ -99,8 +105,10 @@ print('pycicle: path        :', args.pycicle_dir)
 print('pycicle: token       :', args.user_token)
 print('pycicle: machines    :', args.machines)
 print('pycicle: PR          :', args.pull_request)
+print('pycicle: build_type  :', args.build_type)
 #
 machine = args.machines[0]
+build_type = args.build_type
 print('\ncurrent implementation supports only 1 machine :', machine, '\n')
 
 #--------------------------------------------------------------------------
@@ -141,6 +149,7 @@ def launch_build(nickname, compiler, branch_id, branch_name) :
            '-DPYCICLE_RANDOM='              + random_string(10),
            '-DPYCICLE_COMPILER='            + compiler,
            '-DPYCICLE_BOOST='               + boost,
+           '-DPYCICLE_BUILD_TYPE='          + build_type,
            '-DPYCICLE_MASTER='              + github_master,
            # These are to quiet warnings from ctest about unset vars
            '-DCTEST_SOURCE_DIRECTORY=.',


### PR DESCRIPTION
This adds a `-b`/`--build-type` command line option (which is `Release` by default) to set `CMAKE_BUILD_TYPE`.

I've also changed the site and build name variables a bit:
- The site now only contains the system e.g. `cray(daint)`, and nothing about the compiler etc.
- The build name now includes the compiler version, Boost version and the build type. The PR name/number still comes first so that builds can be sorted by PR.