### PR TITLE
Fix params parsing to accept empty string

### DIFF
--- a/pycicle_params.py
+++ b/pycicle_params.py
@@ -71,7 +71,7 @@ class PycicleParams:
                          'in file', config_file)
         with open(config_file, 'r') as f:
             for line in f:
-                m = re.findall(setting + r"\s*\"(.+?)\"", line)
+                m = re.findall(setting + r"\s*\"(.*?)\"", line)
                 if m:
                     self.debug_print('found setting       :', setting, '=', m[0])
                     return m[0]


### PR DESCRIPTION
The old behaviour matched one or more characters. Empty strings are now allowed.

As a result this fixes cdash links on github (which currently contain `None` if `PYCICLE_CDASH_HTTP_PATH` is an empty string).