### PR TITLE
Catch non-existent source repo

### DIFF
--- a/pycicle.py
+++ b/pycicle.py
@@ -572,17 +572,22 @@ if __name__ == "__main__":
             #
             for pr in pull_requests:
                 # find out if the PR is from a local branch or from a clone of the repo
-                pyc_p.debug_print('-' * 30)
-                pyc_p.debug_print(pr)
-                pyc_p.debug_print('Repo to merge from   :', pr.head.repo.owner.login)
-                pyc_p.debug_print('Branch to merge from :', pr.head.ref)
-                if pr.head.repo.owner.login==github_organisation:
-                    pyc_p.debug_print('Pull request is from branch local to repo')
-                else:
-                    pyc_p.debug_print('Pull request is from branch of forked repo')
-                pyc_p.debug_print('git pull https://github.com/' + pr.head.repo.owner.login
+                try:
+                    pyc_p.debug_print('-' * 30)
+                    pyc_p.debug_print(pr)
+                    pyc_p.debug_print('Repo to merge from   :', pr.head.repo.owner.login)
+                    pyc_p.debug_print('Branch to merge from :', pr.head.ref)
+                    if pr.head.repo.owner.login==github_organisation:
+                        pyc_p.debug_print('Pull request is from branch local to repo')
+                    else:
+                        pyc_p.debug_print('Pull request is from branch of forked repo')
+                    pyc_p.debug_print('git pull https://github.com/' + pr.head.repo.owner.login
                                       + '/' + github_reponame + '.git' + ' ' + pr.head.ref)
-                pyc_p.debug_print('-' * 30)
+                    pyc_p.debug_print('-' * 30)
+                except Exception as ex:
+                    pyc_p.debug_print('Could not get information about PR source repo:', ex)
+                    continue
+
                 branch_id   = str(pr.number)
                 branch_name = pr.head.label.rsplit(':',1)[1]
                 branch_sha  = pr.head.sha


### PR DESCRIPTION
Add try-catch around debug printing of PR source repo information. If the source repo has been deleted parts of the pr object are None. If an exception is thrown we skip the PR.

This came up because the forked repo for [this](https://github.com/STEllAR-GROUP/hpx/pull/2859) PR was deleted, causing pycicle to exit with an exception.